### PR TITLE
feat: Add screenshot downsampling and refine LLM config/calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,42 @@
+# .env.example
+
 # Copy this file to .env and fill in your AWS credentials
+
+# --- Project ---
 PROJECT_NAME=omnimcp
+
+# --- Core LLM Configuration ---
+# Required for planning/reasoning steps (Only one provider needed usually)
 ANTHROPIC_API_KEY=your_anthropic_api_key
-# OPENAI_API_KEY=
-# GOOGLE_API_KEY=
-AWS_ACCESS_KEY_ID=your_access_key_id
-AWS_SECRET_ACCESS_KEY=your_secret_access_key
-AWS_REGION=us-east-1
+# Not yet supported:
+# OPENAI_API_KEY=your_openai_api_key
+# GOOGLE_API_KEY=your_google_api_key
+
+# Optional: Specify exact Anthropic model (defaults to "claude-3-7-sonnet-20250219" in config.py)
+# ANTHROPIC_DEFAULT_MODEL=claude-3-sonnet-20240229
+# ANTHROPIC_DEFAULT_MODEL=claude-3-haiku-20240307
+
+# --- OmniParser Service Configuration ---
+# Option 1: Leave blank/commented to use auto-deployment features (requires AWS keys below)
+# OMNIPARSER_URL=
+
+# Option 2: Specify URL if running OmniParser manually or elsewhere
+# OMNIPARSER_URL=http://<your_parser_ip>:8000
+
+# Optional: Factor (0.1-1.0) to resize screenshot before parsing (lower = faster, less accurate)
+# Default is 1.0 (no downsampling). Set to e.g. 0.5 for 50% scaling.
+# OMNIPARSER_DOWNSAMPLE_FACTOR=1.0
+
+# --- AWS Credentials (Required ONLY for OmniParser auto-deployment) ---
+# AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
+# AWS_SECRET_ACCESS_KEY=YOUR_SECRET_KEY
+# AWS_REGION=us-east-1 # Optional: Defaults to us-east-1 if not set
+
+# --- Optional AWS EC2 Configuration (Overrides defaults in config.py for auto-deploy) ---
+# See config.py for default AMI/Instance Type (currently G6/DLAMI)
+# AWS_EC2_INSTANCE_TYPE=g6.xlarge
+# AWS_EC2_AMI=ami-xxxxxxxxxxxxxxxxx
+
+# --- Logging ---
+# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL (Default: INFO)
+# LOG_LEVEL=INFO

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 # --- Logging ---
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL (Default: INFO)
 # LOG_LEVEL=INFO
+#
+# Optional: view full prompts in DEBUG mode
+# DEBUG_FULL_PROMPTS=False

--- a/omnimcp/completions.py
+++ b/omnimcp/completions.py
@@ -63,7 +63,7 @@ def format_chat_messages(messages: List[Dict[str, str]]) -> str:
         content = msg.get("content", "")
         result.append("=" * 40 + f" {role} " + "=" * 40)
         result.append(content)
-    result.append("=" * 80 + "=" * (len(" ASSISTANT ")//2)) # End marker
+    result.append("=" * 80 + "=" * (len(" ASSISTANT ") // 2))  # End marker
     return "\n".join(result)
 
 

--- a/omnimcp/completions.py
+++ b/omnimcp/completions.py
@@ -1,7 +1,9 @@
 # omnimcp/completions.py
+
 import json
 import time
-from typing import Dict, List, Type, TypeVar
+from typing import Dict, List, Optional, Type, TypeVar
+
 import anthropic
 from pydantic import BaseModel, ValidationError
 from tenacity import (
@@ -11,147 +13,179 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from .config import config  # Assuming config has ANTHROPIC_API_KEY
+from .config import config  # Import config for API key and model name
 from .utils import logger  # Reuse logger from utils
-
-# Check for API key
-if not config.ANTHROPIC_API_KEY:
-    raise ValueError("ANTHROPIC_API_KEY not found in environment or .env file.")
-
-# Initialize Anthropic client
-client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
 
 # Type variable for the Pydantic response model
 T = TypeVar("T", bound=BaseModel)
 
-# Define specific exceptions we might want to retry on differently
+# --- Client Initialization ---
+# Initialize based on configured provider (currently only Anthropic)
+# TODO: Add support for other providers (OpenAI, Google) based on config.LLM_PROVIDER
+if config.LLM_PROVIDER.lower() == "anthropic":
+    if not config.ANTHROPIC_API_KEY:
+        raise ValueError(
+            "ANTHROPIC_API_KEY not found in environment/config for Anthropic provider."
+        )
+    try:
+        client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
+        logger.info("Anthropic client initialized.")
+    except Exception as e:
+        logger.critical(f"Failed to initialize Anthropic client: {e}")
+        raise
+else:
+    # In the future, add client init for other providers here
+    logger.warning(
+        f"LLM Provider '{config.LLM_PROVIDER}' not yet fully supported in completions.py. Falling back/failing."
+    )
+    # For now, raise error if not anthropic
+    raise NotImplementedError(
+        f"LLM provider '{config.LLM_PROVIDER}' integration not implemented."
+    )
+
+
+# --- Retry Configuration ---
 RETRYABLE_ERRORS = (
     anthropic.RateLimitError,
     anthropic.APIConnectionError,
     anthropic.InternalServerError,
+    # Add other provider-specific retryable errors here if needed
 )
-
 MAX_RETRIES = 3
-DEFAULT_MODEL = config.ANTHROPIC_DEFAULT_MODEL or "claude-3-7-sonnet-20250219"
 
 
+# --- Helper to format messages for logging ---
+def format_chat_messages(messages: List[Dict[str, str]]) -> str:
+    """Format chat messages in a readable way for logs."""
+    result = []
+    for msg in messages:
+        role = msg.get("role", "unknown").upper()
+        content = msg.get("content", "")
+        result.append("=" * 40 + f" {role} " + "=" * 40)
+        result.append(content)
+    result.append("=" * 80 + "=" * (len(" ASSISTANT ")//2)) # End marker
+    return "\n".join(result)
+
+
+# --- Core API Call Function ---
 @retry(
     retry=retry_if_exception_type(RETRYABLE_ERRORS),
-    wait=wait_random_exponential(min=1, max=30),
+    wait=wait_random_exponential(min=1, max=30),  # Exponential backoff up to 30s
     stop=stop_after_attempt(MAX_RETRIES),
     before_sleep=lambda retry_state: logger.warning(
         f"LLM API Error (Attempt {retry_state.attempt_number}/{MAX_RETRIES}): "
         f"{retry_state.outcome.exception()}. Retrying...",
     ),
+    reraise=True,  # Reraise the exception after retries are exhausted
 )
 def call_llm_api(
     messages: List[Dict[str, str]],
-    response_format: Type[T],
-    model: str = DEFAULT_MODEL,
-    temperature: float = 0.1,  # Lower temperature for more deterministic output
-    system_prompt: str | None = None,  # <-- Add system_prompt argument here
+    response_model: Type[T],
+    model: Optional[str] = None,  # Allow overriding config default
+    temperature: float = 0.1,  # Lower temperature for more deterministic planning
+    system_prompt: Optional[str] = None,
 ) -> T:
     """
-    Calls the Anthropic API, expecting a JSON response conforming to the pydantic model.
+    Calls the configured LLM API, expecting a JSON response conforming to the pydantic model.
 
     Args:
-        messages: List of message dictionaries (system prompt, user message).
-        response_format: The Pydantic model class for the expected JSON structure.
-        model: The Anthropic model to use.
+        messages: List of message dictionaries (e.g., [{"role": "user", "content": ...}]).
+        response_model: The Pydantic model class for the expected JSON structure.
+        model: Optional override for the LLM model name.
         temperature: The sampling temperature.
-        system_prompt: Optional system prompt string. <-- Added description
+        system_prompt: Optional system prompt string.
 
     Returns:
-        An instance of the response_format Pydantic model.
+        An instance of the response_model Pydantic model.
 
     Raises:
-        anthropic.APIError: If a non-retryable API error occurs.
+        anthropic.APIError: If a non-retryable Anthropic API error occurs.
         ValueError: If the response is not valid JSON or doesn't match the schema.
-        Exception: After exceeding retry attempts for retryable errors.
+        NotImplementedError: If the configured LLM provider isn't supported.
+        RetryError: If the call fails after all retry attempts.
+        Exception: For other unexpected errors.
     """
-    logger.debug(
-        f"Calling Anthropic API (model: {model}) with {len(messages)} messages."
-    )
-    if system_prompt:
-        logger.debug(
-            f"System Prompt: {system_prompt[:100]}..."
-        )  # Log beginning of system prompt
+
+    if config.DEBUG_FULL_PROMPTS:
+        formatted_messages = format_chat_messages(messages)
+        logger.debug(f"Formatted messages being sent:\n{formatted_messages}")
+
     start_time = time.time()
 
-    try:
-        response = client.messages.create(
-            model=model,
-            messages=messages,
-            system=system_prompt,  # <-- Pass system_prompt to the API call
-            max_tokens=1024,  # Adjust as needed
-            temperature=temperature,
+    # --- API Specific Call Logic ---
+    # TODO: Add conditional logic here for different providers based on config.LLM_PROVIDER
+    if config.LLM_PROVIDER.lower() == "anthropic":
+        # Use provided model or default from config
+        model_to_use = model or config.ANTHROPIC_DEFAULT_MODEL
+        logger.debug(
+            f"Calling LLM API (model: {model_to_use}) with {len(messages)} messages."
         )
-
-        duration_ms = int((time.time() - start_time) * 1000)
-        logger.debug(f"LLM API call completed in {duration_ms}ms.")
-
-        # Extract the text content
-        if not response.content:
-            logger.error("Received empty content list from API.")
-            raise ValueError("LLM response content is empty.")
-        response_text = response.content[0].text.strip()
-        logger.debug(f"Raw LLM response text:\n{response_text}")
-
-        # Clean potential markdown code fences
-        if response_text.startswith("```json"):
-            response_text = response_text[7:]
-        if response_text.endswith("```"):
-            response_text = response_text[:-3]
-        response_text = response_text.strip()
-
-        # Parse and validate the JSON response using the Pydantic model
         try:
-            parsed_response = response_format.model_validate_json(response_text)
-            logger.info(
-                f"Successfully parsed LLM response into {response_format.__name__}."
+            api_response = client.messages.create(
+                model=model_to_use,
+                messages=messages,
+                system=system_prompt,
+                max_tokens=2048,  # Adjust needed token count
+                temperature=temperature,
             )
-            return parsed_response
-        except ValidationError as e:
+            # Extract text response - specific to Anthropic's Messages API format
+            if (
+                not api_response.content
+                or not isinstance(api_response.content, list)
+                or not hasattr(api_response.content[0], "text")
+            ):
+                logger.error(
+                    f"Unexpected Anthropic API response structure: {api_response}"
+                )
+                raise ValueError(
+                    "Could not extract text content from Anthropic response."
+                )
+            response_text = api_response.content[0].text.strip()
+
+        except anthropic.APIError as e:  # Catch specific non-retryable Anthropic errors
+            logger.error(f"Non-retryable Anthropic API error: {type(e).__name__} - {e}")
+            raise  # Reraise non-retryable or errors hitting max retries
+        except Exception as e:  # Catch other unexpected errors during API call
             logger.error(
-                f"Failed to validate LLM JSON response against schema {response_format.__name__}."
+                f"Unexpected error calling Anthropic API: {type(e).__name__} - {e}",
+                exc_info=True,
             )
-            logger.error(f"Validation Errors: {e}")
-            logger.error(f"Raw response was: {response_text}")
-            raise ValueError(
-                f"LLM response did not match the expected format: {e}"
-            ) from e
-        except json.JSONDecodeError as e:
-            logger.error("Failed to decode LLM response as JSON.")
-            logger.error(f"Raw response was: {response_text}")
-            raise ValueError(f"LLM response was not valid JSON: {e}") from e
-
-    except RETRYABLE_ERRORS as e:
-        logger.warning(f"Encountered retryable API error: {type(e).__name__} - {e}")
-        raise
-    except anthropic.APIError as e:
-        logger.error(f"Non-retryable Anthropic API error: {type(e).__name__} - {e}")
-        raise
-    except Exception as e:
-        logger.error(
-            f"Unexpected error during LLM API call: {type(e).__name__} - {e}",
-            exc_info=True,
+            raise
+    else:
+        # Should have been caught by client init, but safeguard here
+        raise NotImplementedError(
+            f"API call logic for provider '{config.LLM_PROVIDER}' not implemented."
         )
-        raise
+    # --- End API Specific Call Logic ---
 
+    duration_ms = int((time.time() - start_time) * 1000)
+    logger.debug(f"LLM API call completed in {duration_ms}ms.")
+    logger.debug(f"Raw LLM response text:\n{response_text}")
 
-def format_chat_messages(messages: List[Dict[str, str]]) -> str:
-    """Format chat messages in a readable way that preserves formatting."""
-    result = []
+    # Clean potential markdown code fences (common issue)
+    if response_text.startswith("```json"):
+        response_text = response_text[7:]
+    if response_text.endswith("```"):
+        response_text = response_text[:-3]
+    response_text = response_text.strip()
 
-    for msg in messages:
-        role = msg.get("role")
-        content = msg.get("content")
-
-        # Add a separator line
-        result.append("=" * 80)
-        result.append(f"ROLE: {role}")
-        result.append("-" * 80)
-        result.append(content)
-
-    result.append("=" * 80)
-    return "\n".join(result)
+    # Parse and validate the JSON response using the Pydantic model
+    try:
+        parsed_response = response_model.model_validate_json(response_text)
+        logger.info(f"Successfully parsed LLM response into {response_model.__name__}.")
+        return parsed_response
+    except ValidationError as e:
+        logger.error(
+            f"Failed to validate LLM JSON response against schema {response_model.__name__}."
+        )
+        logger.error(f"Validation Errors: {e}")
+        logger.error(f"Response JSON text was: {response_text}")
+        # Don't raise e directly, wrap it
+        raise ValueError(f"LLM response did not match the expected format: {e}") from e
+    except json.JSONDecodeError as e:
+        logger.error("Failed to decode LLM response as JSON.")
+        logger.error(f"Raw response text was: {response_text}")
+        raise ValueError(f"LLM response was not valid JSON: {e}") from e
+    except Exception as e:
+        logger.error(f"Unexpected error during Pydantic validation: {e}", exc_info=True)
+        raise  # Reraise unexpected validation errors

--- a/omnimcp/config.py
+++ b/omnimcp/config.py
@@ -13,8 +13,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class OmniMCPConfig(BaseSettings):
     """Configuration settings for OmniMCP."""
 
-    DEBUG_FULL_PROMPTS: bool = False
-
     LLM_PROVIDER: str = "anthropic"
 
     # Claude API configuration
@@ -63,6 +61,7 @@ class OmniMCPConfig(BaseSettings):
     # Debug settings
     # DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
+    DEBUG_FULL_PROMPTS: bool = False
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/omnimcp/config.py
+++ b/omnimcp/config.py
@@ -6,22 +6,33 @@ import os
 from typing import Optional
 from pathlib import Path
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class OmniMCPConfig(BaseSettings):
     """Configuration settings for OmniMCP."""
 
+    DEBUG_FULL_PROMPTS: bool = False
+
+    LLM_PROVIDER: str = "anthropic"
+
     # Claude API configuration
     ANTHROPIC_API_KEY: Optional[str] = None
     ANTHROPIC_DEFAULT_MODEL: str = "claude-3-7-sonnet-20250219"
     # ANTHROPIC_DEFAULT_MODEL: str = "claude-3-haiku-20240307"
 
-    # Auto-shutdown OmniParser after 60min inactivity
-    INACTIVITY_TIMEOUT_MINUTES: int = 60
-
     # OmniParser configuration
+    PROJECT_NAME: str = "omnimcp"
     OMNIPARSER_URL: Optional[str] = None
+    OMNIPARSER_DOWNSAMPLE_FACTOR: float = 1.0
+    OMNIPARSER_DOWNSAMPLE_FACTOR: float = Field(
+        1.0,
+        ge=0.1,  # Minimum factor 10%
+        le=1.0,  # Maximum factor 100%
+        description="Factor to downsample screenshot before OmniParser (lower=faster, less accurate)",
+    )
+    INACTIVITY_TIMEOUT_MINUTES: int = 60
 
     # AWS deployment settings (for remote OmniParser)
     AWS_ACCESS_KEY_ID: Optional[str] = None
@@ -29,7 +40,6 @@ class OmniMCPConfig(BaseSettings):
     AWS_REGION: Optional[str] = "us-west-2"
 
     # OmniParser deployment configuration
-    PROJECT_NAME: str = "omniparser"
     REPO_URL: str = "https://github.com/microsoft/OmniParser.git"
     # AWS_EC2_AMI: str = "ami-06835d15c4de57810"
     AWS_EC2_AMI: str = (

--- a/omnimcp/core.py
+++ b/omnimcp/core.py
@@ -46,11 +46,14 @@ Here is a list of UI elements currently visible on the screen (showing first 50 
     * If the goal requires an application (like 'calculator') that is *not* visible, and the previous action was *not* pressing the OS search key ("Cmd+Space" or "Win"), then the next action is to press the OS search key: `action: "press_key"`, `key_info: "Cmd+Space"` (or "Win" depending on OS).
     * **IMPORTANT:** If the previous action *was* pressing the OS search key, AND a search input field is now visible in the **Current UI Elements**, then the next action is to type the application name: `action: "type"`, `text_to_type: "Calculator"` (or the specific app name needed), `element_id: <ID of search input field, if available, otherwise null>`.
     * If the previous action was typing the application name into search, the next action is to press Enter: `action: "press_key"`, `key_info: "Enter"`.
-4.  **General Action Selection:**
-    * If not launching an app, identify the most relevant visible UI element to interact with next (click, type). Choose `action: "click"` or `action: "type"` and provide the correct `element_id`.
-    * If typing into a field, set `text_to_type`. Otherwise, it must be null.
-    * Use `action: "scroll"` (e.g., `key_info: "down"`) if necessary to find elements, setting other fields to null.
-    * For any `press_key` action, `element_id` and `text_to_type` must be null. Provide the key name/combo in `key_info`.
+4.  **General Action Selection & Output Format Rules:**
+    * Identify the most relevant visible UI element for the next logical step based on your reasoning.
+    * **Rule 1:** If `action` is 'click', `element_id` MUST be the integer ID of a visible element from the list. `text_to_type` and `key_info` MUST be null.
+    * **Rule 2:** If `action` is 'type', `text_to_type` MUST be the string to type. `key_info` MUST be null. `element_id` SHOULD be the ID of the target field if identifiable, otherwise null (if typing into a general area like Spotlight).
+    * **Rule 3:** If `action` is 'press_key', `key_info` MUST be the key/shortcut string (e.g., 'Enter', 'Cmd+Space', 'a', '*'). `element_id` and `text_to_type` MUST be null.
+    * **Rule 4:** If `action` is 'scroll', provide scroll details if possible (or default to generic scroll). `element_id`, `text_to_type`, `key_info` MUST be null.
+    * **Rule 5:** If the desired element for the next logical step (e.g., the '*' button) is **not found** in the 'Current UI Elements', DO NOT choose `action: "click"` with `element_id: null`. Instead, consider if an alternative valid action like `action: "press_key"` (e.g., with `key_info: "*"`) can achieve the result. If no suitable action exists, explain this in the reasoning and select an action like waiting or reporting failure if appropriate (though the current actions don't support waiting/failure reporting well).
+    * **Rule 6:** Ensure your entire output is ONLY the single, valid JSON object conforming to the structure, with no extra text or markdown.
 5.  **Goal Completion:** If the goal is fully achieved, set `is_goal_complete: true`. Otherwise, set `is_goal_complete: false`.
 6.  **Output Format:** Respond ONLY with a valid JSON object matching the structure below. Do NOT include ```json markdown.
 

--- a/omnimcp/utils.py
+++ b/omnimcp/utils.py
@@ -596,3 +596,43 @@ def draw_action_highlight(
         return image.copy()  # Return copy of original on error
 
     return final_image
+
+
+def downsample_image(image: Image.Image, factor: float) -> Image.Image:
+    """
+    Downsamples a PIL Image by a given factor using LANCZOS resampling.
+
+    Args:
+        image: The original PIL Image.
+        factor: The scaling factor (e.g., 0.5 for 50%). Must be > 0 and <= 1.
+
+    Returns:
+        The downsampled PIL Image. Returns original if factor is invalid or error occurs.
+    """
+    if not (0.0 < factor <= 1.0):
+        logger.warning(
+            f"Invalid downsample factor ({factor}). Returning original image."
+        )
+        return image
+    if factor == 1.0:
+        return image  # No scaling needed
+
+    try:
+        original_dimensions = image.size
+        new_width = int(original_dimensions[0] * factor)
+        new_height = int(original_dimensions[1] * factor)
+        # Ensure dimensions are at least 1x1
+        new_width = max(1, new_width)
+        new_height = max(1, new_height)
+
+        start_time = time.time()
+        # Use LANCZOS for potentially better quality downsampling
+        scaled_image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+        duration = (time.time() - start_time) * 1000
+        logger.debug(
+            f"Resized image from {original_dimensions} to {scaled_image.size} (factor {factor:.2f}) in {duration:.1f}ms"
+        )
+        return scaled_image
+    except Exception as resize_err:
+        logger.warning(f"Failed to downsample image, returning original: {resize_err}")
+        return image  # Fallback to original on error


### PR DESCRIPTION
- Adds OMNIPARSER_DOWNSAMPLE_FACTOR config variable to allow scaling
  screenshots before parsing (default 1.0). Implemented via new
  utils.downsample_image function called from visual_state.py.
- Adds LLM_PROVIDER and ANTHROPIC_DEFAULT_MODEL config variables.
- Updates completions.py to use config, add tenacity retries, and
  restore/use format_chat_messages (guarded by new DEBUG_FULL_PROMPTS config flag).
- Fixes test failures in test_visual_state.py related to mock data and patches.

Agent planning sequence for calculator task now appears correct with Sonnet
and downsample_factor=1.0, although perception (~7-11s) and planning
(~5-9s) steps remain slow. Downsampling factor < 1.0 can be enabled via
.env for performance testing, but may affect accuracy.