### PR TITLE
fix: clear ruff 0.16 findings and bound the linter version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,15 +40,18 @@ from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("omnimcp")
 
+
 @mcp.tool()
 async def get_screen_state() -> ScreenState:
     """Get current state of visible UI elements"""
-    
+
+
 @mcp.tool()
 async def click_element(description: str) -> ClickResult:
     """Click UI element matching description"""
 
-@mcp.tool() 
+
+@mcp.tool()
 async def type_text(text: str) -> TypeResult:
     """Type text"""
 ```
@@ -118,11 +121,13 @@ class UIElement:
     bounds: Bounds
     confidence: float
 
+
 @dataclass
 class ScreenState:
     elements: List[UIElement]
     dimensions: tuple[int, int]
     timestamp: float
+
 
 @dataclass
 class ActionResult:
@@ -268,9 +273,9 @@ class ActionVerification:
     changes_detected: List[BoundingBox]
     confidence: float
 
+
 async def verify_tool_execution(
-    action_result: ActionResult,
-    verification: ActionVerification
+    action_result: ActionResult, verification: ActionVerification
 ) -> bool:
     """Verify tool executed successfully"""
 ```
@@ -345,19 +350,20 @@ class VisualState:
 ```python
 class OmniParserClient:
     """Client for interacting with the OmniParser API."""
-    
+
     def parse_image(self, image: Image.Image) -> Dict[str, Any]:
         """Parse an image using the OmniParser service."""
-        
+
     def check_server_available(self) -> bool:
         """Check if the OmniParser server is available."""
 
+
 class OmniParserProvider:
     """Provider for OmniParser services with deployment capabilities."""
-    
+
     def deploy(self) -> bool:
         """Deploy OmniParser if not already running."""
-    
+
     def is_available(self) -> bool:
         """Check if parser is available."""
 ```
@@ -381,17 +387,14 @@ class InputController:
 ```python
 class ClaudeVision:
     """Handles visual analysis using Claude."""
-    
+
     async def describe_elements(
-        elements: List[Element],
-        context: Optional[Image] = None
+        elements: List[Element], context: Optional[Image] = None
     ) -> List[str]:
         """Get detailed descriptions of UI elements."""
-        
+
     async def analyze_visual_query(
-        query: str,
-        screenshot: Image,
-        elements: List[Element]
+        query: str, screenshot: Image, elements: List[Element]
     ) -> Dict:
         """Answer questions about UI using Claude's vision."""
 ```
@@ -735,19 +738,19 @@ def generate_action_test_pair(action_type="click"):
     before_img, elements = generate_test_ui()
     after_img = before_img.copy()
     after_draw = ImageDraw.Draw(after_img)
-    
+
     if action_type == "click":
         # Show button in pressed state
-        after_draw.rectangle([(100, 100), (200, 150)], fill='darkblue', outline='black')
+        after_draw.rectangle([(100, 100), (200, 150)], fill="darkblue", outline="black")
         after_draw.text((110, 115), "Submit", fill="white")
         # Add success message
         after_draw.text((100, 170), "Form submitted!", fill="green")
-    
+
     elif action_type == "type":
         # Show text entered in field
-        after_draw.rectangle([(300, 100), (500, 150)], fill='white', outline='black')
+        after_draw.rectangle([(300, 100), (500, 150)], fill="white", outline="black")
         after_draw.text((310, 115), "testuser", fill="black")
-    
+
     return before_img, after_img, elements
 ```
 
@@ -760,12 +763,12 @@ async def test_element_finding():
     """Test Claude's ability to find elements in synthetic UI."""
     # Generate test image with known elements
     test_img, elements = generate_test_ui()
-    
+
     # Mock screenshot capture to return test image
-    with patch('omnimcp.utils.take_screenshot', return_value=test_img):
+    with patch("omnimcp.utils.take_screenshot", return_value=test_img):
         # Setup OmniMCP with mock parser that returns our elements
-        # ... 
-        
+        # ...
+
         # Test with various descriptions
         descriptions = [
             "submit button",
@@ -773,7 +776,7 @@ async def test_element_finding():
             "the username field",
             "textbox in the middle",
         ]
-        
+
         for desc in descriptions:
             # Call find_element with each description
             element = await mcp._visual_state.find_element(desc)

--- a/cli.py
+++ b/cli.py
@@ -45,17 +45,17 @@ def run(
     # Delay imports to avoid credential checks at import time
     try:
         # Import necessary components from the project
-        from omnimcp.config import config
-        from omnimcp.input import InputController, _pynput_error
         from omnimcp.agent_executor import AgentExecutor
+        from omnimcp.config import config
         from omnimcp.core import plan_action_for_ui
+        from omnimcp.input import InputController, _pynput_error
         from omnimcp.omniparser.client import OmniParserClient
-        from omnimcp.visual_state import VisualState
         from omnimcp.utils import (
-            draw_bounding_boxes,
-            draw_action_highlight,
             NSScreen,  # Check for AppKit on macOS
+            draw_action_highlight,
+            draw_bounding_boxes,
         )
+        from omnimcp.visual_state import VisualState
     except ImportError as e:
         logger.critical(f"Required dependency not found: {e}")
         return 1

--- a/demo_synthetic.py
+++ b/demo_synthetic.py
@@ -6,17 +6,17 @@ Generates UI images and simulates the loop without real screen interaction.
 
 import os
 import time
-from typing import List, Optional
+
+from omnimcp.core import LLMActionPlan, plan_action_for_ui
 
 # Import necessary components from the project
 from omnimcp.synthetic_ui import (
+    draw_highlight,  # Use the original draw_highlight from synthetic_ui
     generate_login_screen,
     simulate_action,
-    draw_highlight,  # Use the original draw_highlight from synthetic_ui
 )
-from omnimcp.core import plan_action_for_ui, LLMActionPlan
-from omnimcp.utils import logger
 from omnimcp.types import UIElement
+from omnimcp.utils import logger
 
 # NOTE ON REFACTORING:
 # The main loop structure in this script (run_synthetic_planner_demo) is similar
@@ -56,7 +56,7 @@ def run_synthetic_planner_demo():
     user_goal = "Log in using username 'testuser' and password 'password123'"
     logger.info(f"User Goal: '{user_goal}'")
 
-    action_history: List[str] = []
+    action_history: list[str] = []
     goal_achieved_flag = False
     last_step_completed = -1
 
@@ -78,8 +78,8 @@ def run_synthetic_planner_demo():
 
         # 2. Plan Next Action
         logger.info("Planning action with LLM...")
-        llm_plan: Optional[LLMActionPlan] = None
-        target_element: Optional[UIElement] = None
+        llm_plan: LLMActionPlan | None = None
+        target_element: UIElement | None = None
         try:
             llm_plan, target_element = plan_action_for_ui(
                 elements=elements,
@@ -106,12 +106,15 @@ def run_synthetic_planner_demo():
                 goal_achieved_flag = True
 
             # --- Updated Validation Check ---
-            if not goal_achieved_flag:
-                if llm_plan.action == "click" and not target_element:
-                    logger.error(
-                        f"LLM planned 'click' on invalid element ID ({llm_plan.element_id}). Stopping."
-                    )
-                    break
+            if (
+                not goal_achieved_flag
+                and llm_plan.action == "click"
+                and not target_element
+            ):
+                logger.error(
+                    f"LLM planned 'click' on invalid element ID ({llm_plan.element_id}). Stopping."
+                )
+                break
 
             # 4. Visualize Planned Action (uses synthetic_ui.draw_highlight)
             highlight_img_path = os.path.join(

--- a/docs/testing_strategy.md
+++ b/docs/testing_strategy.md
@@ -21,16 +21,18 @@ def setup_virtual_display():
     """Setup virtual display for UI testing."""
     try:
         from pyvirtualdisplay import Display
+
         display = Display(visible=0, size=(1280, 1024))
         display.start()
-        
+
         # Use a headless browser
         from selenium import webdriver
+
         options = webdriver.ChromeOptions()
-        options.add_argument('--headless')
+        options.add_argument("--headless")
         driver = webdriver.Chrome(options=options)
         driver.get("http://localhost:8080/testpage.html")
-        
+
         return display, driver
     except ImportError:
         # Handle platforms without Xvfb support
@@ -55,18 +57,18 @@ Generate test images programmatically with known UI elements:
 def create_test_images():
     """Generate synthetic UI test images."""
     from PIL import Image, ImageDraw, ImageFont
-    
+
     # Before image with button
-    before = Image.new('RGB', (800, 600), color='white')
+    before = Image.new("RGB", (800, 600), color="white")
     draw = ImageDraw.Draw(before)
-    draw.rectangle([(100, 100), (250, 150)], fill='blue')
+    draw.rectangle([(100, 100), (250, 150)], fill="blue")
     draw.text((125, 115), "Test Button", fill="white")
-    
+
     # After image with success message
     after = before.copy()
     draw = ImageDraw.Draw(after)
     draw.text((100, 170), "Success! Button was clicked.", fill="green")
-    
+
     return before, after
 ```
 
@@ -89,27 +91,29 @@ Mock the screenshot and parsing components to return predefined data:
 def mock_visual_pipeline():
     """Patch the visual pipeline components for testing."""
     patches = []
-    
+
     # Mock screenshot function
     before_img, after_img = create_test_images()
     mock_screenshot = MagicMock(return_value=before_img)
-    patches.append(patch('omnimcp.utils.take_screenshot', mock_screenshot))
-    
+    patches.append(patch("omnimcp.utils.take_screenshot", mock_screenshot))
+
     # Create predefined elements
     test_elements = [
         {
             "type": "button",
             "content": "Test Button",
             "bounds": {"x": 100, "y": 100, "width": 150, "height": 50},
-            "confidence": 1.0
+            "confidence": 1.0,
         }
     ]
-    
+
     # Mock parser
     mock_parser = MagicMock()
     mock_parser.parse_image.return_value = {"parsed_content_list": test_elements}
-    patches.append(patch('omnimcp.omniparser.client.OmniParserClient', return_value=mock_parser))
-    
+    patches.append(
+        patch("omnimcp.omniparser.client.OmniParserClient", return_value=mock_parser)
+    )
+
     return patches
 ```
 
@@ -184,32 +188,23 @@ def get_test_environment():
     """Determine test environment and return appropriate testing setup."""
     is_ci = os.environ.get("CI", "0") == "1"
     platform = sys.platform
-    
+
     if is_ci:
         # In CI, use synthetic images
         return {
             "type": "synthetic",
             "images": create_test_images(),
-            "elements": create_test_elements()
+            "elements": create_test_elements(),
         }
     elif platform == "darwin":  # macOS
         # On macOS developer machine, use real UI
-        return {
-            "type": "real",
-            "setup": lambda: start_test_app()
-        }
+        return {"type": "real", "setup": lambda: start_test_app()}
     elif platform == "win32":  # Windows
         # On Windows, use headless browser
-        return {
-            "type": "headless",
-            "setup": lambda: setup_headless_browser()
-        }
+        return {"type": "headless", "setup": lambda: setup_headless_browser()}
     else:  # Linux or other
         # On Linux, use Xvfb
-        return {
-            "type": "xvfb",
-            "setup": lambda: setup_virtual_display()
-        }
+        return {"type": "xvfb", "setup": lambda: setup_virtual_display()}
 ```
 
 **Pros:**

--- a/make_gif.py
+++ b/make_gif.py
@@ -1,11 +1,11 @@
 # make_gif.py
+import glob
 import os
 import sys
-import glob
-from PIL import Image
+
 import fire
-from typing import List
 from loguru import logger  # Use logger for consistency
+from PIL import Image
 
 
 def create_gif(
@@ -54,7 +54,7 @@ def create_gif(
         sys.exit(1)
 
     # Create list of image objects
-    frames: List[Image.Image] = []
+    frames: list[Image.Image] = []
     try:
         logger.info("Opening image files...")
         for filename in png_files:

--- a/omnimcp/__init__.py
+++ b/omnimcp/__init__.py
@@ -1,5 +1,6 @@
-import sys
 import os
+import sys
+
 from loguru import logger
 
 from omnimcp.config import config

--- a/omnimcp/agent_executor.py
+++ b/omnimcp/agent_executor.py
@@ -3,10 +3,10 @@
 import datetime
 import os
 import time
-from typing import Callable, List, Optional, Tuple, Protocol, Dict
+from collections.abc import Callable
+from typing import Protocol
 
 from PIL import Image
-
 
 from omnimcp import config, setup_run_logging
 from omnimcp.types import LLMActionPlan, UIElement
@@ -21,9 +21,9 @@ from omnimcp.utils import (
 
 
 class PerceptionInterface(Protocol):
-    elements: List[UIElement]
-    screen_dimensions: Optional[Tuple[int, int]]
-    _last_screenshot: Optional[Image.Image]
+    elements: list[UIElement]
+    screen_dimensions: tuple[int, int] | None
+    _last_screenshot: Image.Image | None
 
     def update(self) -> None: ...
 
@@ -36,8 +36,8 @@ class ExecutionInterface(Protocol):
 
 
 PlannerCallable = Callable[
-    [List[UIElement], str, List[str], int, str],
-    Tuple[LLMActionPlan, Optional[UIElement]],
+    [list[UIElement], str, list[str], int, str],
+    tuple[LLMActionPlan, UIElement | None],
 ]
 ImageProcessorCallable = Callable[..., Image.Image]
 
@@ -56,18 +56,18 @@ class AgentExecutor:
         perception: PerceptionInterface,
         planner: PlannerCallable,
         execution: ExecutionInterface,
-        box_drawer: Optional[ImageProcessorCallable] = draw_bounding_boxes,
-        highlighter: Optional[ImageProcessorCallable] = draw_action_highlight,
+        box_drawer: ImageProcessorCallable | None = draw_bounding_boxes,
+        highlighter: ImageProcessorCallable | None = draw_action_highlight,
     ):
         self._perception = perception
         self._planner = planner
         self._execution = execution
         self._box_drawer = box_drawer
         self._highlighter = highlighter
-        self.action_history: List[str] = []
+        self.action_history: list[str] = []
 
         # Map action names to their handler methods
-        self._action_handlers: Dict[str, Callable[..., bool]] = {
+        self._action_handlers: dict[str, Callable[..., bool]] = {
             "click": self._execute_click,
             "type": self._execute_type,
             "press_key": self._execute_press_key,
@@ -80,8 +80,8 @@ class AgentExecutor:
     def _execute_click(
         self,
         plan: LLMActionPlan,
-        target_element: Optional[UIElement],
-        screen_dims: Tuple[int, int],
+        target_element: UIElement | None,
+        screen_dims: tuple[int, int],
         scaling_factor: int,
     ) -> bool:
         """Handles the 'click' action."""
@@ -110,8 +110,8 @@ class AgentExecutor:
     def _execute_type(
         self,
         plan: LLMActionPlan,
-        target_element: Optional[UIElement],
-        screen_dims: Tuple[int, int],
+        target_element: UIElement | None,
+        screen_dims: tuple[int, int],
         scaling_factor: int,
     ) -> bool:
         """Handles the 'type' action."""
@@ -146,8 +146,8 @@ class AgentExecutor:
     def _execute_press_key(
         self,
         plan: LLMActionPlan,
-        target_element: Optional[UIElement],  # Unused, but maintains handler signature
-        screen_dims: Tuple[int, int],  # Unused
+        target_element: UIElement | None,  # Unused, but maintains handler signature
+        screen_dims: tuple[int, int],  # Unused
         scaling_factor: int,  # Unused
     ) -> bool:
         """Handles the 'press_key' action."""
@@ -160,8 +160,8 @@ class AgentExecutor:
     def _execute_scroll(
         self,
         plan: LLMActionPlan,
-        target_element: Optional[UIElement],  # Unused
-        screen_dims: Tuple[int, int],  # Unused
+        target_element: UIElement | None,  # Unused
+        screen_dims: tuple[int, int],  # Unused
         scaling_factor: int,  # Unused
     ) -> bool:
         """Handles the 'scroll' action."""
@@ -203,7 +203,7 @@ class AgentExecutor:
     # these alternatives for more complex or reactive tasks.
 
     def run(
-        self, goal: str, max_steps: int = 10, output_base_dir: Optional[str] = None
+        self, goal: str, max_steps: int = 10, output_base_dir: str | None = None
     ) -> bool:
         """
         Runs the main perceive-plan-act loop to achieve the goal.
@@ -222,7 +222,11 @@ class AgentExecutor:
         if output_base_dir is None:
             output_base_dir = config.RUN_OUTPUT_DIR
 
-        run_timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_timestamp = (
+            datetime.datetime.now(datetime.timezone.utc)
+            .astimezone()
+            .strftime("%Y%m%d_%H%M%S")
+        )
         run_output_dir = os.path.join(output_base_dir, run_timestamp)
 
         try:
@@ -255,9 +259,9 @@ class AgentExecutor:
             logger.info(f"\n--- Step {step + 1}/{max_steps} ---")
             step_start_time = time.time()
             step_img_prefix = f"step_{step + 1}"
-            current_image: Optional[Image.Image] = None
-            current_elements: List[UIElement] = []
-            screen_dimensions: Optional[Tuple[int, int]] = None
+            current_image: Image.Image | None = None
+            current_elements: list[UIElement] = []
+            screen_dimensions: tuple[int, int] | None = None
 
             # 1. Perceive State
             try:
@@ -302,8 +306,8 @@ class AgentExecutor:
                     logger.warning(f"Could not save parsed state image: {draw_boxes_e}")
 
             # 3. Plan Action (Unchanged)
-            llm_plan: Optional[LLMActionPlan] = None
-            target_element: Optional[UIElement] = None
+            llm_plan: LLMActionPlan | None = None
+            target_element: UIElement | None = None
             try:
                 logger.debug("Planning next action...")
                 llm_plan, target_element = self._planner(

--- a/omnimcp/completions.py
+++ b/omnimcp/completions.py
@@ -2,7 +2,7 @@
 
 import json
 import time
-from typing import Dict, List, Optional, Type, TypeVar
+from typing import TypeVar
 
 import anthropic
 from pydantic import BaseModel, ValidationError
@@ -55,7 +55,7 @@ MAX_RETRIES = 3
 
 
 # --- Helper to format messages for logging ---
-def format_chat_messages(messages: List[Dict[str, str]]) -> str:
+def format_chat_messages(messages: list[dict[str, str]]) -> str:
     """Format chat messages in a readable way for logs."""
     result = []
     for msg in messages:
@@ -79,11 +79,11 @@ def format_chat_messages(messages: List[Dict[str, str]]) -> str:
     reraise=True,  # Reraise the exception after retries are exhausted
 )
 def call_llm_api(
-    messages: List[Dict[str, str]],
-    response_model: Type[T],
-    model: Optional[str] = None,  # Allow overriding config default
+    messages: list[dict[str, str]],
+    response_model: type[T],
+    model: str | None = None,  # Allow overriding config default
     temperature: float = 0.1,  # Lower temperature for more deterministic planning
-    system_prompt: Optional[str] = None,
+    system_prompt: str | None = None,
 ) -> T:
     """
     Calls the configured LLM API, expecting a JSON response conforming to the pydantic model.
@@ -163,10 +163,8 @@ def call_llm_api(
     logger.debug(f"Raw LLM response text:\n{response_text}")
 
     # Clean potential markdown code fences (common issue)
-    if response_text.startswith("```json"):
-        response_text = response_text[7:]
-    if response_text.endswith("```"):
-        response_text = response_text[:-3]
+    response_text = response_text.removeprefix("```json")
+    response_text = response_text.removesuffix("```")
     response_text = response_text.strip()
 
     # Parse and validate the JSON response using the Pydantic model

--- a/omnimcp/config.py
+++ b/omnimcp/config.py
@@ -3,7 +3,6 @@
 """Configuration management for OmniMCP."""
 
 import os
-from typing import Optional
 from pathlib import Path
 
 from pydantic import Field
@@ -16,14 +15,13 @@ class OmniMCPConfig(BaseSettings):
     LLM_PROVIDER: str = "anthropic"
 
     # Claude API configuration
-    ANTHROPIC_API_KEY: Optional[str] = None
+    ANTHROPIC_API_KEY: str | None = None
     ANTHROPIC_DEFAULT_MODEL: str = "claude-3-7-sonnet-20250219"
     # ANTHROPIC_DEFAULT_MODEL: str = "claude-3-haiku-20240307"
 
     # OmniParser configuration
     PROJECT_NAME: str = "omnimcp"
-    OMNIPARSER_URL: Optional[str] = None
-    OMNIPARSER_DOWNSAMPLE_FACTOR: float = 1.0
+    OMNIPARSER_URL: str | None = None
     OMNIPARSER_DOWNSAMPLE_FACTOR: float = Field(
         1.0,
         ge=0.1,  # Minimum factor 10%
@@ -33,9 +31,9 @@ class OmniMCPConfig(BaseSettings):
     INACTIVITY_TIMEOUT_MINUTES: int = 60
 
     # AWS deployment settings (for remote OmniParser)
-    AWS_ACCESS_KEY_ID: Optional[str] = None
-    AWS_SECRET_ACCESS_KEY: Optional[str] = None
-    AWS_REGION: Optional[str] = "us-west-2"
+    AWS_ACCESS_KEY_ID: str | None = None
+    AWS_SECRET_ACCESS_KEY: str | None = None
+    AWS_REGION: str | None = "us-west-2"
 
     # OmniParser deployment configuration
     REPO_URL: str = "https://github.com/microsoft/OmniParser.git"
@@ -52,7 +50,7 @@ class OmniMCPConfig(BaseSettings):
     COMMAND_TIMEOUT: int = 600  # 10 minutes
 
     # Logging configuration
-    LOG_DIR: Optional[str] = "logs"
+    LOG_DIR: str | None = "logs"
     DISABLE_DEFAULT_LOGGING: bool = False
 
     # Run output configuration

--- a/omnimcp/core.py
+++ b/omnimcp/core.py
@@ -1,17 +1,14 @@
 # omnimcp/core.py
-from typing import List, Tuple, Optional
-
 import platform
 
-# Assuming these imports are correct
-from .types import UIElement
-from .utils import (
-    render_prompt,
-    logger,
-)  # Assuming render_prompt handles template creation
 from .completions import call_llm_api
-from .types import LLMActionPlan
 
+# Assuming these imports are correct
+from .types import LLMActionPlan, UIElement
+from .utils import (
+    logger,
+    render_prompt,
+)  # Assuming render_prompt handles template creation
 
 PROMPT_TEMPLATE = """
 You are an expert UI automation assistant. Your task is to determine the single next best action to take on a user interface (UI) to achieve a given user goal, and assess if the goal is already complete.
@@ -73,12 +70,12 @@ Here is a list of UI elements currently visible on the screen (showing first 50 
 # --- Core Logic Function plan_action_for_ui (remains the same as previous version) ---
 # Includes the temporary debug logging for elements on step 2
 def plan_action_for_ui(
-    elements: List[UIElement],
+    elements: list[UIElement],
     user_goal: str,
-    action_history: List[str] | None = None,
+    action_history: list[str] | None = None,
     # Add step parameter for conditional logging (adjust call in demo.py)
     step: int = 0,
-) -> Tuple[LLMActionPlan, Optional[UIElement]]:
+) -> tuple[LLMActionPlan, UIElement | None]:
     """
     Uses an LLM to plan the next UI action based on elements, goal, and history.
     """

--- a/omnimcp/input.py
+++ b/omnimcp/input.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import time
-from typing import Optional, Literal, List, Tuple, Dict, Any, Union
+from typing import Any, ClassVar, Literal
 
 from loguru import logger
 
@@ -34,10 +34,10 @@ else:
     _pynput_error = "Skipping pynput import in headless Linux environment (no DISPLAY)."
     logger.warning(_pynput_error)
 
-from omnimcp.utils import log_action  # noqa: E402
+from omnimcp.utils import log_action
 
 # Define Bounds type if not imported from elsewhere
-BoundsTuple = Tuple[float, float, float, float]  # (norm_x, norm_y, norm_w, norm_h)
+BoundsTuple = tuple[float, float, float, float]  # (norm_x, norm_y, norm_w, norm_h)
 
 
 class InputController:
@@ -47,7 +47,7 @@ class InputController:
     """
 
     # --- Moved _special_map_definitions to be a Class Attribute ---
-    _special_map_definitions: Dict[str, str] = {
+    _special_map_definitions: ClassVar[dict[str, str]] = {
         # Alias      : pynput Key attribute name
         "enter": "enter",
         "return": "enter",
@@ -113,7 +113,7 @@ class InputController:
         logger.info("pynput mouse and keyboard controllers initialized.")
 
         # --- Mappings referencing Class Attribute ---
-        self.MODIFIER_MAP: Dict[str, Any] = {
+        self.MODIFIER_MAP: dict[str, Any] = {
             "cmd": self.Key.cmd,
             "command": self.Key.cmd,
             "win": self.Key.cmd,
@@ -126,7 +126,7 @@ class InputController:
         logger.debug(f"Initialized MODIFIER_MAP with {len(self.MODIFIER_MAP)} keys.")
 
         # Helper to safely get key attribute
-        def _get_key(key_name: str) -> Optional[Any]:
+        def _get_key(key_name: str) -> Any | None:
             try:
                 return getattr(self.Key, key_name)
             except AttributeError:
@@ -136,7 +136,7 @@ class InputController:
                 return None
 
         # Build the instance's SPECIAL_KEY_MAP safely using the class attribute definitions
-        self.SPECIAL_KEY_MAP: Dict[str, Any] = {}
+        self.SPECIAL_KEY_MAP: dict[str, Any] = {}
         missing_keys = set()
         # Use self._special_map_definitions or InputController._special_map_definitions here
         for alias, key_name in InputController._special_map_definitions.items():
@@ -255,8 +255,8 @@ class InputController:
             part.strip().lower() for part in key_info_str.replace("-", "+").split("+")
         ]
 
-        modifiers_to_press: List[keyboard.Key] = []
-        primary_key_str: Optional[str] = None
+        modifiers_to_press: list[keyboard.Key] = []
+        primary_key_str: str | None = None
 
         # 1. Parse the string
         for part in parts:
@@ -275,7 +275,7 @@ class InputController:
                 return False
 
         # 2. Determine primary key object
-        primary_key_obj: Optional[Union[str, keyboard.Key, keyboard.KeyCode]] = None
+        primary_key_obj: str | keyboard.Key | keyboard.KeyCode | None = None
         if primary_key_str:
             if primary_key_str in self.SPECIAL_KEY_MAP:
                 primary_key_obj = self.SPECIAL_KEY_MAP[primary_key_str]

--- a/omnimcp/mcp_server.py
+++ b/omnimcp/mcp_server.py
@@ -2,7 +2,7 @@
 
 import sys
 import time
-from typing import List, Literal, Optional
+from typing import Literal
 
 import numpy as np
 from loguru import logger
@@ -14,22 +14,22 @@ from PIL import Image
 # Imports needed by OmniMCP class and its tools
 from omnimcp.config import config  # Import config to read URL
 from omnimcp.input import InputController
-from omnimcp.utils import compute_diff, denormalize_coordinates
-from omnimcp.types import (
-    Bounds,
-    UIElement,
-    ScreenState,
-    ActionVerification,
-    InteractionResult,
-    ScrollResult,
-    TypeResult,
-)
-
-# Import VisualState from its new location
-from omnimcp.visual_state import VisualState
 
 # Import parser client as it's needed to init VisualState here
 from omnimcp.omniparser.client import OmniParserClient
+from omnimcp.types import (
+    ActionVerification,
+    Bounds,
+    InteractionResult,
+    ScreenState,
+    ScrollResult,
+    TypeResult,
+    UIElement,
+)
+from omnimcp.utils import compute_diff, denormalize_coordinates
+
+# Import VisualState from its new location
+from omnimcp.visual_state import VisualState
 
 
 class OmniMCP:
@@ -130,26 +130,31 @@ class OmniMCP:
             return f"Found {element.type} with content '{element.content}' at bounds {element.bounds}"
 
         @self.mcp.tool()
-        def find_elements(query: str, max_results: int = 5) -> List[UIElement]:
+        def find_elements(query: str, max_results: int = 5) -> list[UIElement]:
             """Find elements matching natural query (Basic implementation)."""
             logger.info(f"MCP Tool: find_elements '{query}' (max: {max_results})")
             self._visual_state.update()
             # TODO: Enhance matching logic (e.g., vector search, LLM).
             matching_elements = []
             for element in self._visual_state.elements:
-                if element.content and any(
-                    word in element.content.lower()
-                    for word in query.lower().split()
-                    if word
+                if (
+                    element.content
+                    and any(
+                        word in element.content.lower()
+                        for word in query.lower().split()
+                        if word
+                    )
+                    or (
+                        element.type
+                        and any(
+                            word in element.type.lower()
+                            for word in query.lower().split()
+                            if word
+                        )
+                        and element not in matching_elements
+                    )
                 ):
                     matching_elements.append(element)
-                elif element.type and any(
-                    word in element.type.lower()
-                    for word in query.lower().split()
-                    if word
-                ):
-                    if element not in matching_elements:
-                        matching_elements.append(element)
                 if len(matching_elements) >= max_results:
                     break
             logger.info(
@@ -253,7 +258,7 @@ class OmniMCP:
             )
 
         @self.mcp.tool()
-        def type_text(text: str, target: Optional[str] = None) -> TypeResult:
+        def type_text(text: str, target: str | None = None) -> TypeResult:
             """
             Type text. If target description is provided, updates state, finds/clicks
             the target first. Otherwise, types immediately assuming focus is correct.
@@ -379,11 +384,11 @@ class OmniMCP:
     # _verify_action is kept as a helper, though not called by default tools now
     def _verify_action(
         self,
-        before_image: Optional[Image.Image],
-        after_image: Optional[Image.Image],
-        element_bounds: Optional[Bounds] = None,
-        action_description: Optional[str] = None,
-    ) -> Optional[ActionVerification]:
+        before_image: Image.Image | None,
+        after_image: Image.Image | None,
+        element_bounds: Bounds | None = None,
+        action_description: str | None = None,
+    ) -> ActionVerification | None:
         """Verify action success using basic pixel difference."""
         # TODO: Refactor verification logic: Consider moving to a dedicated verification module, improving the diff algorithm (e.g., structural diff), or making verification optional via config due to performance impact and current basic implementation.
         logger.debug("MCP Tool: Verifying action using pixel difference...")

--- a/omnimcp/omniparser/client.py
+++ b/omnimcp/omniparser/client.py
@@ -3,21 +3,20 @@
 """Client module for interacting with the OmniParser server."""
 
 import base64
-from typing import Optional, Dict, List
 
-from loguru import logger
-from PIL import Image, ImageDraw
 import boto3  # Need boto3 for the initial check
 import requests
+from loguru import logger
+from PIL import Image, ImageDraw
 
-from .server import Deploy
 from ..config import config
+from .server import Deploy
 
 
 class OmniParserClient:
     """Client for interacting with the OmniParser server."""
 
-    def __init__(self, server_url: Optional[str] = None, auto_deploy: bool = True):
+    def __init__(self, server_url: str | None = None, auto_deploy: bool = True):
         """Initialize the OmniParser client.
 
         Args:
@@ -51,7 +50,7 @@ class OmniParserClient:
                 )
                 # Get the most recently launched running instance
                 running_instances = sorted(
-                    list(instances), key=lambda i: i.launch_time, reverse=True
+                    instances, key=lambda i: i.launch_time, reverse=True
                 )
                 instance = running_instances[0] if running_instances else None
 
@@ -137,7 +136,7 @@ class OmniParserClient:
             )
             raise RuntimeError(f"Server probe failed: {e}") from e
 
-    def parse_image(self, image: Image.Image) -> Dict:
+    def parse_image(self, image: Image.Image) -> dict:
         """Parse an image using the OmniParser server.
 
         Args:
@@ -171,7 +170,7 @@ class OmniParserClient:
         return base64.b64encode(buffered.getvalue()).decode()
 
     def visualize_results(
-        self, image: Image.Image, parsed_content: List[Dict]
+        self, image: Image.Image, parsed_content: list[dict]
     ) -> Image.Image:
         """Visualize parsing results on the image.
 

--- a/omnimcp/omniparser/mapper.py
+++ b/omnimcp/omniparser/mapper.py
@@ -1,21 +1,21 @@
 # omnimcp/omniparser/mapper.py
 
-from typing import List, Dict, Any  # Added Any
+from typing import Any  # Added Any
 
 from loguru import logger
 
 # Assuming types are imported correctly
-from omnimcp.types import UIElement, Bounds  # Assuming Bounds is tuple (x,y,w,h)
+from omnimcp.types import Bounds, UIElement  # Assuming Bounds is tuple (x,y,w,h)
 
 
 def map_omniparser_to_uielements(
-    parser_json: Dict, img_width: int, img_height: int
-) -> List[UIElement]:
+    parser_json: dict, img_width: int, img_height: int
+) -> list[UIElement]:
     """Converts raw OmniParser JSON output to a list of UIElement objects."""
-    elements: List[UIElement] = []
+    elements: list[UIElement] = []
     element_id_counter = 0
     # Adjust key if needed based on actual OmniParser output schema
-    raw_elements: List[Dict[str, Any]] = parser_json.get("parsed_content_list", [])
+    raw_elements: list[dict[str, Any]] = parser_json.get("parsed_content_list", [])
 
     if not isinstance(raw_elements, list):
         logger.error(

--- a/omnimcp/omniparser/server.py
+++ b/omnimcp/omniparser/server.py
@@ -3,19 +3,19 @@
 """Deployment module for OmniParser on AWS EC2 with on-demand startup and ALARM-BASED auto-shutdown."""
 
 import datetime
+import io
+import json
 import os
 import subprocess
 import time
-import json
-import io
 import zipfile
-from typing import Tuple  # Added for type hinting consistency
+from collections.abc import Sequence
 
-from botocore.exceptions import ClientError
-from loguru import logger
 import boto3
 import fire
 import paramiko
+from botocore.exceptions import ClientError
+from loguru import logger
 
 # Assuming config is imported correctly from omnimcp.config
 from omnimcp.config import config
@@ -68,8 +68,17 @@ def create_key_pair(
             return None
 
 
-def get_or_create_security_group_id(ports: list[int] = [22, config.PORT]) -> str | None:
+# Evaluated once at import, exactly as the old mutable default argument was,
+# but as an immutable tuple so a caller cannot mutate every later call's default.
+_DEFAULT_SECURITY_GROUP_PORTS: tuple[int, ...] = (22, config.PORT)
+
+
+def get_or_create_security_group_id(
+    ports: Sequence[int] | None = None,
+) -> str | None:
     """Get existing security group or create a new one."""
+    if ports is None:
+        ports = _DEFAULT_SECURITY_GROUP_PORTS
     ec2_client = boto3.client("ec2", region_name=config.AWS_REGION)
     sg_name = config.AWS_EC2_SECURITY_GROUP
 
@@ -169,7 +178,7 @@ def deploy_ec2_instance(
     project_name: str = config.PROJECT_NAME,
     key_name: str = config.AWS_EC2_KEY_NAME,
     disk_size: int = config.AWS_EC2_DISK_SIZE,
-) -> Tuple[str | None, str | None]:
+) -> tuple[str | None, str | None]:
     """
     Deploy a new EC2 instance or start/return an existing usable one.
     Ignores instances that are shutting-down or terminated.
@@ -208,9 +217,7 @@ def deploy_ec2_instance(
         )
 
         # Find the most recently launched instance in a usable state
-        sorted_instances = sorted(
-            list(instances), key=lambda i: i.launch_time, reverse=True
-        )
+        sorted_instances = sorted(instances, key=lambda i: i.launch_time, reverse=True)
 
         if sorted_instances:
             candidate_instance = sorted_instances[0]
@@ -551,7 +558,7 @@ def execute_command(
     max_retries: int = 20,
     retry_delay: int = 10,
     timeout: int = config.COMMAND_TIMEOUT,  # Use timeout from config
-) -> Tuple[int, str, str]:  # Return status, stdout, stderr
+) -> tuple[int, str, str]:  # Return status, stdout, stderr
     """Execute a command via SSH with retries for specific errors."""
     logger.info(
         f"Executing SSH command: {command[:100]}{'...' if len(command) > 100 else ''}"
@@ -560,7 +567,7 @@ def execute_command(
     while attempt < max_retries:
         attempt += 1
         try:
-            stdin, stdout, stderr = ssh_client.exec_command(
+            _stdin, stdout, stderr = ssh_client.exec_command(
                 command,
                 timeout=timeout,
                 get_pty=False,  # Try without PTY first
@@ -980,7 +987,7 @@ class Deploy:
     """Class handling deployment operations for OmniParser."""
 
     @staticmethod
-    def start() -> Tuple[str | None, str | None]:  # Added return type hint
+    def start() -> tuple[str | None, str | None]:  # Added return type hint
         """
         Start or configure EC2 instance, setup auto-shutdown, deploy OmniParser container.
         Returns the public IP and instance ID on success, or (None, None) on failure.
@@ -1513,13 +1520,16 @@ class Deploy:
                         "echo 'SSH connection successful'",
                     ]
                     result = subprocess.run(
-                        test_ssh_cmd, capture_output=True, text=True
+                        test_ssh_cmd, capture_output=True, text=True, check=False
                     )
                     if result.returncode == 0:
                         logger.info("Instance is ready for SSH connections")
                         return
-                except Exception:
-                    pass
+                except Exception as e:
+                    # Expected while the instance is still booting; keep
+                    # retrying, but do not swallow it silently -- a
+                    # misconfigured key path looked identical to "not up yet".
+                    logger.debug(f"SSH readiness probe failed: {e}")
 
                 time.sleep(10)  # Wait 10 seconds between attempts
 
@@ -1573,7 +1583,7 @@ class Deploy:
         logger.info(f"Retrieving {days} days of deployment history...")
 
         # Calculate time range
-        end_time = datetime.datetime.now()
+        end_time = datetime.datetime.now(datetime.timezone.utc)
         start_time = end_time - datetime.timedelta(days=days)
 
         # Initialize AWS clients
@@ -1615,7 +1625,7 @@ class Deploy:
                 # Get instance console output if available
                 try:
                     console = ec2_client.get_console_output(InstanceId=instance_id)
-                    if "Output" in console and console["Output"]:
+                    if console.get("Output"):
                         logger.info("Last console output (truncated):")
                         # Show last few lines of console output
                         lines = console["Output"].strip().split("\n")
@@ -1662,7 +1672,7 @@ class Deploy:
 
                     for event in logs.get("events", []):
                         timestamp = datetime.datetime.fromtimestamp(
-                            event["timestamp"] / 1000
+                            event["timestamp"] / 1000, tz=datetime.timezone.utc
                         )
                         message = event["message"]
                         logger.info(f"  {timestamp}: {message}")

--- a/omnimcp/synthetic_ui.py
+++ b/omnimcp/synthetic_ui.py
@@ -1,10 +1,11 @@
 # omnimcp/synthetic_ui.py
-import os
-from typing import List, Tuple, Any
-from PIL import Image, ImageDraw, ImageFont, ImageEnhance
 import copy  # For deep copying element list
+import os
+from typing import Any
 
-from .types import UIElement, Bounds
+from PIL import Image, ImageDraw, ImageEnhance, ImageFont
+
+from .types import Bounds, UIElement
 from .utils import logger
 
 # --- Constants and Font ---
@@ -12,14 +13,14 @@ IMG_WIDTH, IMG_HEIGHT = 800, 600
 try:
     FONT = ImageFont.truetype("arial.ttf", 15)
     FONT_BOLD = ImageFont.truetype("arialbd.ttf", 20)  # Added bold font
-except IOError:
+except OSError:
     logger.warning("Arial fonts not found. Using default PIL font.")
     FONT = ImageFont.load_default()
     FONT_BOLD = ImageFont.load_default()
 
 
 # --- Coordinate Conversion ---
-def _bounds_to_abs(bounds: Bounds) -> Tuple[int, int, int, int]:
+def _bounds_to_abs(bounds: Bounds) -> tuple[int, int, int, int]:
     """Convert normalized bounds to absolute pixel coordinates."""
     x, y, w, h = bounds
     abs_x = int(x * IMG_WIDTH)
@@ -29,7 +30,7 @@ def _bounds_to_abs(bounds: Bounds) -> Tuple[int, int, int, int]:
     return abs_x, abs_y, abs_w, abs_h
 
 
-def _abs_to_bounds(abs_coords: Tuple[int, int, int, int]) -> Bounds:
+def _abs_to_bounds(abs_coords: tuple[int, int, int, int]) -> Bounds:
     """Convert absolute pixel coordinates to normalized bounds."""
     abs_x, abs_y, abs_w, abs_h = abs_coords
     x = abs_x / IMG_WIDTH
@@ -44,11 +45,11 @@ def _abs_to_bounds(abs_coords: Tuple[int, int, int, int]) -> Bounds:
 
 def generate_login_screen(
     save_path: str | None = None,
-) -> Tuple[Image.Image, List[UIElement]]:
+) -> tuple[Image.Image, list[UIElement]]:
     """Generates the initial synthetic login screen image and element data."""
     img = Image.new("RGB", (IMG_WIDTH, IMG_HEIGHT), color=(230, 230, 230))
     draw = ImageDraw.Draw(img)
-    elements: List[UIElement] = []
+    elements: list[UIElement] = []
     element_id_counter = 0
 
     # Title
@@ -170,13 +171,13 @@ def generate_login_screen(
 
 def generate_logged_in_screen(
     username: str, save_path: str | None = None
-) -> Tuple[Image.Image, List[UIElement]]:
+) -> tuple[Image.Image, list[UIElement]]:
     """Generates a simple 'logged in' screen."""
     img = Image.new(
         "RGB", (IMG_WIDTH, IMG_HEIGHT), color=(210, 230, 210)
     )  # Light green background
     draw = ImageDraw.Draw(img)
-    elements: List[UIElement] = []
+    elements: list[UIElement] = []
     element_id_counter = 0  # Start fresh IDs for new screen state
 
     # Welcome Message
@@ -240,10 +241,10 @@ def generate_logged_in_screen(
 
 def simulate_action(
     image: Image.Image,
-    elements: List[UIElement],
+    elements: list[UIElement],
     plan: Any,  # Using Any to avoid circular import with core.py/LLMActionPlan
     username_for_login: str = "User",  # Default username for welcome screen
-) -> Tuple[Image.Image, List[UIElement]]:
+) -> tuple[Image.Image, list[UIElement]]:
     """
     Simulates the effect of a planned action on the synthetic UI state.
 
@@ -410,7 +411,7 @@ def draw_highlight(
     width: int = 3,
     dim_factor: float = 0.5,
     text_color: str = "black",  # Color for annotation text
-    text_bg_color: Tuple[int, int, int, int] = (
+    text_bg_color: tuple[int, int, int, int] = (
         255,
         255,
         255,

--- a/omnimcp/testing_utils.py
+++ b/omnimcp/testing_utils.py
@@ -5,8 +5,9 @@ Utilities for generating synthetic UI images and test data for OmniMCP tests.
 """
 
 import os
+from typing import Any
+
 from PIL import Image, ImageDraw, ImageFont
-from typing import List, Dict, Tuple, Any, Optional
 
 # Assuming types are implicitly available via callers or add specific imports if needed
 # from .types import Bounds # Assuming Bounds = Tuple[float, float, float, float]
@@ -15,15 +16,15 @@ from typing import List, Dict, Tuple, Any, Optional
 try:
     # Adjust path if needed, but rely on default if not found
     FONT = ImageFont.truetype("arial.ttf", 15)
-except IOError:
+except OSError:
     # logger.warning("Arial font not found. Using default PIL font.") # logger might not be configured here
     print("Warning: Arial font not found. Using default PIL font.")
     FONT = ImageFont.load_default()
 
 
 def generate_test_ui(
-    save_path: Optional[str] = None,
-) -> Tuple[Image.Image, List[Dict[str, Any]]]:
+    save_path: str | None = None,
+) -> tuple[Image.Image, list[dict[str, Any]]]:
     """
     Generate synthetic UI image with known elements.
 
@@ -118,8 +119,8 @@ def generate_test_ui(
 
 
 def generate_action_test_pair(
-    action_type: str = "click", target: str = "button", save_dir: Optional[str] = None
-) -> Tuple[Image.Image, Image.Image, List[Dict[str, Any]]]:
+    action_type: str = "click", target: str = "button", save_dir: str | None = None
+) -> tuple[Image.Image, Image.Image, list[dict[str, Any]]]:
     """Generate before/after UI image pair for a specific action."""
     temp_save_path = None
     if save_dir:

--- a/omnimcp/tracking.py
+++ b/omnimcp/tracking.py
@@ -1,9 +1,7 @@
 # omnimcp/tracking.py
-from typing import List, Dict, Optional, Tuple
 
 # Use typing_extensions for Self if needed for older Python versions
 # from typing_extensions import Self
-
 # Added Scipy for matching
 import numpy as np
 
@@ -24,7 +22,7 @@ except ImportError:
 
 # Assuming UIElement and ElementTrack are defined in omnimcp.types
 try:
-    from omnimcp.types import UIElement, ElementTrack, Bounds
+    from omnimcp.types import Bounds, ElementTrack, UIElement
 except ImportError:
     print("Warning: Could not import types from omnimcp.types")
     UIElement = dict  # type: ignore
@@ -39,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 # Helper Function (can stay here or move to utils)
-def _get_bounds_center(bounds: Bounds) -> Optional[Tuple[float, float]]:
+def _get_bounds_center(bounds: Bounds) -> tuple[float, float] | None:
     """Calculate the center (relative coords) of a bounding box."""
     if not isinstance(bounds, (list, tuple)) or len(bounds) != 4:
         logger.warning(
@@ -76,7 +74,7 @@ class SimpleElementTracker:
                 "Scipy is required for SimpleElementTracker matching logic but not installed."
             )
             # raise ImportError("Scipy is required for SimpleElementTracker")
-        self.tracked_elements: Dict[str, ElementTrack] = {}  # track_id -> ElementTrack
+        self.tracked_elements: dict[str, ElementTrack] = {}  # track_id -> ElementTrack
         self.next_track_id_counter: int = 0
         self.miss_threshold = miss_threshold
         # Store squared threshold for efficiency
@@ -91,7 +89,7 @@ class SimpleElementTracker:
         self.next_track_id_counter += 1
         return track_id
 
-    def _match_elements(self, current_elements: List[UIElement]) -> Dict[int, str]:
+    def _match_elements(self, current_elements: list[UIElement]) -> dict[int, str]:
         """
         Performs optimal assignment matching between current elements and active tracks.
 
@@ -175,10 +173,10 @@ class SimpleElementTracker:
         for i in range(num_current):
             for j in range(num_tracks):
                 # Infinite cost if types don't match
-                if current_types[i] != track_types[j]:
-                    cost_matrix[i, j] = infinity_cost
-                # Infinite cost if distance exceeds threshold
-                elif cost_matrix[i, j] > self.match_threshold_sq:
+                if (
+                    current_types[i] != track_types[j]
+                    or cost_matrix[i, j] > self.match_threshold_sq
+                ):
                     cost_matrix[i, j] = infinity_cost
 
         # --- Optimal Assignment using Hungarian Algorithm ---
@@ -191,7 +189,7 @@ class SimpleElementTracker:
             return {}
 
         # --- Create Mapping from Valid Assignments ---
-        assignment_mapping: Dict[int, str] = {}  # current_element_id -> track_id
+        assignment_mapping: dict[int, str] = {}  # current_element_id -> track_id
         valid_matches_count = 0
         for r, c in zip(row_ind, col_ind):
             # Check if the assignment cost is valid (not infinity)
@@ -205,8 +203,8 @@ class SimpleElementTracker:
         return assignment_mapping
 
     def update(
-        self, current_elements: List[UIElement], frame_number: int
-    ) -> List[ElementTrack]:
+        self, current_elements: list[UIElement], frame_number: int
+    ) -> list[ElementTrack]:
         """
         Updates tracks based on current detections using optimal assignment matching.
 
@@ -225,7 +223,7 @@ class SimpleElementTracker:
         matched_current_element_ids = set(assignment_mapping.keys())
         matched_track_ids = set(assignment_mapping.values())
 
-        tracks_to_prune: List[str] = []
+        tracks_to_prune: list[str] = []
         # Update existing tracks based on matches
         for track_id, track in self.tracked_elements.items():
             if track_id in matched_track_ids:

--- a/omnimcp/types.py
+++ b/omnimcp/types.py
@@ -2,13 +2,13 @@
 
 import time
 from dataclasses import dataclass, field
-from typing import List, Optional, Dict, Any, Tuple, Literal
+from typing import Any, Literal
 
 from loguru import logger
-from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 # Define Bounds (assuming normalized coordinates 0.0-1.0)
-Bounds = Tuple[float, float, float, float]  # (x, y, width, height)
+Bounds = tuple[float, float, float, float]  # (x, y, width, height)
 
 
 # --- Core Data Structures (Using Dataclasses as provided) ---
@@ -24,9 +24,9 @@ class UIElement:
     content: str  # Text content or accessibility label
     bounds: Bounds  # Normalized coordinates (x, y, width, height)
     confidence: float = 1.0
-    attributes: Dict[str, Any] = field(default_factory=dict)  # e.g., {'checked': False}
+    attributes: dict[str, Any] = field(default_factory=dict)  # e.g., {'checked': False}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert UIElement to a dictionary."""
         return {
             "id": self.id,
@@ -67,8 +67,8 @@ class UIElement:
 class ScreenState:
     """Represents the raw state of the screen at a point in time."""
 
-    elements: List[UIElement]
-    dimensions: Tuple[int, int]  # Actual pixel dimensions
+    elements: list[UIElement]
+    dimensions: tuple[int, int]  # Actual pixel dimensions
     timestamp: float
 
 
@@ -82,7 +82,7 @@ class ActionVerification:
     success: bool
     before_state: bytes  # Screenshot bytes
     after_state: bytes  # Screenshot bytes
-    changes_detected: List[Bounds]  # Regions where changes occurred
+    changes_detected: list[Bounds]  # Regions where changes occurred
     confidence: float
 
 
@@ -91,10 +91,10 @@ class InteractionResult:
     """Generic result of an interaction attempt."""
 
     success: bool
-    element: Optional[UIElement]  # The element interacted with, if applicable
-    error: Optional[str] = None
-    context: Dict[str, Any] = field(default_factory=dict)
-    verification: Optional[ActionVerification] = None
+    element: UIElement | None  # The element interacted with, if applicable
+    error: str | None = None
+    context: dict[str, Any] = field(default_factory=dict)
+    verification: ActionVerification | None = None
 
 
 @dataclass
@@ -119,10 +119,10 @@ class ToolError:
     """Rich error information, potentially for MCP tools or agent errors."""
 
     message: str
-    visual_context: Optional[bytes]  # Screenshot bytes
+    visual_context: bytes | None  # Screenshot bytes
     attempted_action: str
     element_description: str  # Description or ID of intended target
-    recovery_suggestions: List[str]
+    recovery_suggestions: list[str]
 
 
 @dataclass
@@ -130,11 +130,11 @@ class DebugContext:
     """Context for debugging a specific operation or tool call."""
 
     tool_name: str
-    inputs: Dict[str, Any]
+    inputs: dict[str, Any]
     result: Any
     duration: float
-    visual_state: Optional[ScreenState]  # Raw screen state at the time
-    error: Optional[Dict] = None  # e.g., ToolError as dict
+    visual_state: ScreenState | None  # Raw screen state at the time
+    error: dict | None = None  # e.g., ToolError as dict
 
     def save_snapshot(self, path: str) -> None:
         """Save debug snapshot for analysis."""
@@ -161,22 +161,22 @@ class LLMActionPlan(BaseModel):
         ...,
         description="Set to true if the user's overall goal is fully achieved by the current state, false otherwise.",
     )
-    element_id: Optional[int] = Field(
+    element_id: int | None = Field(
         default=None,
         description="The per-frame ID of the target UI element IF the action is 'click' or 'type' and goal is not complete. Must be null otherwise.",
     )
-    text_to_type: Optional[str] = Field(
+    text_to_type: str | None = Field(
         default=None,
         description="Text to type IF action is 'type' and goal is not complete. Must be null otherwise.",
     )
-    key_info: Optional[str] = Field(
+    key_info: str | None = Field(
         default=None,
         description="Key or shortcut to press IF action is 'press_key' and goal is not complete (e.g., 'Enter', 'Cmd+Space'). Must be null otherwise.",
     )
 
     @field_validator("element_id")
     @classmethod
-    def check_element_id(cls, v: Optional[int], info: ValidationInfo) -> Optional[int]:
+    def check_element_id(cls, v: int | None, info: ValidationInfo) -> int | None:
         # Skip validation if goal is already complete
         if info.data.get("is_goal_complete", False):
             return v
@@ -194,9 +194,7 @@ class LLMActionPlan(BaseModel):
 
     @field_validator("text_to_type")
     @classmethod
-    def check_text_to_type(
-        cls, v: Optional[str], info: ValidationInfo
-    ) -> Optional[str]:
+    def check_text_to_type(cls, v: str | None, info: ValidationInfo) -> str | None:
         if info.data.get("is_goal_complete", False):
             return v
         action = info.data.get("action")
@@ -212,7 +210,7 @@ class LLMActionPlan(BaseModel):
 
     @field_validator("key_info")
     @classmethod
-    def check_key_info(cls, v: Optional[str], info: ValidationInfo) -> Optional[str]:
+    def check_key_info(cls, v: str | None, info: ValidationInfo) -> str | None:
         if info.data.get("is_goal_complete", False):
             return v
         action = info.data.get("action")
@@ -237,7 +235,7 @@ class ElementTrack(BaseModel):
         description="Persistent tracking ID assigned by the tracker (e.g., 'track_0')"
     )
     # Storing Optional[UIElement] (dataclass) directly in Pydantic model works
-    latest_element: Optional[UIElement] = Field(
+    latest_element: UIElement | None = Field(
         None,
         description="The UIElement dataclass instance detected in the current frame, if any.",
     )
@@ -270,19 +268,19 @@ class ScreenAnalysis(BaseModel):
     reasoning: str = Field(
         description="Detailed reasoning about the UI state, changes, and tracked elements relevant to the goal."
     )
-    disappeared_elements: List[str] = Field(
+    disappeared_elements: list[str] = Field(
         default_factory=list,
         description="List of track_ids considered permanently gone.",
     )
-    temporarily_missing_elements: List[str] = Field(
+    temporarily_missing_elements: list[str] = Field(
         default_factory=list,
         description="List of track_ids considered temporarily missing but likely to reappear.",
     )
-    new_elements: List[str] = Field(
+    new_elements: list[str] = Field(
         default_factory=list,
         description="List of track_ids for newly appeared elements.",
     )
-    critical_elements_status: Dict[str, str] = Field(
+    critical_elements_status: dict[str, str] = Field(
         default_factory=dict,
         description="Status (e.g., 'Visible', 'Missing', 'Gone') of track_ids deemed critical for the current goal/step.",
     )
@@ -297,11 +295,11 @@ class ActionDecision(BaseModel):
     action_type: str = Field(
         description="The type of action to perform (e.g., 'click', 'type', 'press_key', 'wait', 'finish')."
     )
-    target_element_id: Optional[int] = Field(
+    target_element_id: int | None = Field(
         None,
         description="The CURRENT per-frame 'id' of the target UIElement, if applicable and visible.",
     )
-    parameters: Dict[str, Any] = Field(
+    parameters: dict[str, Any] = Field(
         default_factory=dict,
         description="Action parameters, e.g., {'text_to_type': 'hello', 'key_info': 'Enter'}",
     )
@@ -319,31 +317,31 @@ class LoggedStep(BaseModel):
     step_index: int
     timestamp: float = Field(default_factory=time.time)
     goal: str
-    screenshot_path: Optional[str] = None  # Relative path within run dir
+    screenshot_path: str | None = None  # Relative path within run dir
 
     # Inputs to Planner
     input_elements_count: int
     # Store list of dicts for JSON serialization compatibility
-    tracking_context: Optional[List[Dict]] = Field(
+    tracking_context: list[dict] | None = Field(
         None, description="Snapshot of ElementTrack data (as dicts) provided to LLM"
     )
-    action_history_at_step: List[str]
+    action_history_at_step: list[str]
 
     # Planner Outputs (Store as dicts)
-    llm_analysis: Optional[Dict] = Field(
+    llm_analysis: dict | None = Field(
         None, description="ScreenAnalysis output from LLM"
     )
-    llm_decision: Optional[Dict] = Field(
+    llm_decision: dict | None = Field(
         None, description="ActionDecision output from LLM"
     )
-    raw_llm_action_plan: Optional[Dict] = Field(
+    raw_llm_action_plan: dict | None = Field(
         None, description="LLMActionPlan if ActionDecision not yet implemented"
     )
 
     # Execution
     executed_action: str
-    executed_target_element_id: Optional[int] = None
-    executed_parameters: Dict[str, Any]
+    executed_target_element_id: int | None = None
+    executed_parameters: dict[str, Any]
     action_success: bool
 
     # Metrics

--- a/omnimcp/utils.py
+++ b/omnimcp/utils.py
@@ -2,19 +2,20 @@
 
 """Minimal utilities needed for OmniMCP."""
 
-from functools import wraps
-from io import BytesIO
-from typing import Any, Callable, List, Tuple, Union, Optional
 import base64
 import sys
+import textwrap
 import threading
 import time
-import textwrap
+from collections.abc import Callable
+from functools import wraps
+from io import BytesIO
+from typing import Any
 
+import mss
 from jinja2 import Environment, Template
 from loguru import logger
-from PIL import Image, ImageDraw, ImageFont, ImageEnhance
-import mss
+from PIL import Image, ImageDraw, ImageEnhance, ImageFont
 
 if sys.platform == "darwin":
     try:
@@ -27,7 +28,7 @@ if sys.platform == "darwin":
 else:
     NSScreen = None  # Define as None on other platforms
 
-from .types import UIElement, LLMActionPlan
+from .types import LLMActionPlan, UIElement
 
 # Process-local storage for MSS instances
 _process_local = threading.local()
@@ -53,7 +54,7 @@ def take_screenshot() -> Image.Image:
     return image
 
 
-def get_monitor_dims() -> Tuple[int, int]:
+def get_monitor_dims() -> tuple[int, int]:
     """Get the dimensions reported by mss for the primary monitor."""
     # This might return logical points or physical pixels depending on backend/OS.
     # The scaling factor helps bridge the gap regardless.
@@ -67,7 +68,7 @@ def get_monitor_dims() -> Tuple[int, int]:
     return dims
 
 
-def image_to_base64(image: Union[str, Image.Image]) -> str:
+def image_to_base64(image: str | Image.Image) -> str:
     """Convert image to base64 string.
 
     Args:
@@ -97,7 +98,7 @@ def log_action(func: Callable) -> Callable:
             logger.debug(f"{func.__name__} completed in {duration:.2f}ms")
             return result
         except Exception as e:
-            logger.error(f"{func.__name__} failed: {str(e)}")
+            logger.error(f"{func.__name__} failed: {e!s}")
             raise
 
     return wrapper
@@ -108,9 +109,9 @@ def denormalize_coordinates(
     norm_y: float,
     screen_w: int,
     screen_h: int,  # These are PHYSICAL PIXEL dimensions of the screenshot
-    norm_w: Optional[float] = None,
-    norm_h: Optional[float] = None,
-) -> Tuple[int, int]:
+    norm_w: float | None = None,
+    norm_h: float | None = None,
+) -> tuple[int, int]:
     """
     Convert normalized coordinates (relative to screenshot) to
     ABSOLUTE PHYSICAL PIXEL coordinates.
@@ -132,7 +133,7 @@ def denormalize_coordinates(
 
 def normalize_coordinates(
     x: int, y: int, screen_w: int, screen_h: int
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     if screen_w <= 0 or screen_h <= 0:
         logger.warning(
             f"Invalid screen dimensions ({screen_w}x{screen_h}), cannot normalize."
@@ -143,7 +144,7 @@ def normalize_coordinates(
     return norm_x, norm_y
 
 
-def get_scale_ratios() -> Tuple[float, float]:
+def get_scale_ratios() -> tuple[float, float]:
     """Get the scale ratios between actual screen dimensions and image dimensions.
 
     Handles high DPI/Retina displays where screenshot dimensions may differ from
@@ -172,7 +173,7 @@ def get_scale_ratios() -> Tuple[float, float]:
     return width_ratio, height_ratio
 
 
-def screen_to_image_coords(x: int, y: int) -> Tuple[int, int]:
+def screen_to_image_coords(x: int, y: int) -> tuple[int, int]:
     """Convert screen coordinates to image coordinates.
 
     Args:
@@ -188,7 +189,7 @@ def screen_to_image_coords(x: int, y: int) -> Tuple[int, int]:
     return image_x, image_y
 
 
-def image_to_screen_coords(x: int, y: int) -> Tuple[int, int]:
+def image_to_screen_coords(x: int, y: int) -> tuple[int, int]:
     """Convert image coordinates to screen coordinates.
 
     Args:
@@ -309,7 +310,7 @@ def create_prompt_template(template_str: str) -> Template:
     return env.from_string(template_str)
 
 
-def render_prompt(template: Union[Template, str], **kwargs: Any) -> str:
+def render_prompt(template: Template | str, **kwargs: Any) -> str:
     """Create and render a prompt template in one step.
 
     Args:
@@ -342,7 +343,7 @@ def render_prompt(template: Union[Template, str], **kwargs: Any) -> str:
 
 def draw_bounding_boxes(
     image: Image.Image,
-    elements: List["UIElement"],
+    elements: list["UIElement"],
     color: str = "red",
     width: int = 1,
     show_ids: bool = True,
@@ -373,7 +374,7 @@ def draw_bounding_boxes(
             # font = ImageFont.truetype("arial.ttf", 12) # Might fail if not installed
             font_size = 12
             font = ImageFont.load_default(size=font_size)
-        except IOError:
+        except OSError:
             logger.warning(
                 "Default font not found for drawing IDs. Using basic PIL font."
             )
@@ -457,7 +458,7 @@ def get_scaling_factor() -> int:
 try:
     # Adjust size as needed
     ACTION_FONT = ImageFont.truetype("arial.ttf", 14)
-except IOError:
+except OSError:
     logger.warning("Arial font not found for highlighting. Using default PIL font.")
     ACTION_FONT = ImageFont.load_default()
 
@@ -470,7 +471,7 @@ def draw_action_highlight(
     width: int = 3,
     dim_factor: float = 0.5,
     text_color: str = "black",
-    text_bg_color: Tuple[int, int, int, int] = (255, 255, 255, 200),  # White with alpha
+    text_bg_color: tuple[int, int, int, int] = (255, 255, 255, 200),  # White with alpha
 ) -> Image.Image:
     """
     Draws highlight box, dims background, and adds text annotation for the planned action,

--- a/omnimcp/visual_state.py
+++ b/omnimcp/visual_state.py
@@ -5,15 +5,15 @@ Manages the perceived state of the UI using screenshots and OmniParser.
 """
 
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
-from PIL import Image
 from loguru import logger
+from PIL import Image
 
 from omnimcp.config import config
 from omnimcp.omniparser.client import OmniParserClient
 from omnimcp.types import Bounds, UIElement
-from omnimcp.utils import take_screenshot, downsample_image
+from omnimcp.utils import downsample_image, take_screenshot
 
 
 class VisualState:
@@ -24,14 +24,12 @@ class VisualState:
 
     def __init__(self, parser_client: OmniParserClient):
         """Initialize the visual state manager."""
-        self.elements: List[UIElement] = []
-        self.timestamp: Optional[float] = None
-        self.screen_dimensions: Optional[Tuple[int, int]] = (
+        self.elements: list[UIElement] = []
+        self.timestamp: float | None = None
+        self.screen_dimensions: tuple[int, int] | None = (
             None  # Stores ORIGINAL dimensions
         )
-        self._last_screenshot: Optional[Image.Image] = (
-            None  # Stores ORIGINAL screenshot
-        )
+        self._last_screenshot: Image.Image | None = None  # Stores ORIGINAL screenshot
         self._parser_client = parser_client
         if not self._parser_client:
             logger.critical("VisualState initialized without a valid parser_client!")
@@ -46,7 +44,7 @@ class VisualState:
         """
         logger.info("VisualState update requested...")
         start_time = time.time()
-        screenshot: Optional[Image.Image] = None  # Define screenshot outside try
+        screenshot: Image.Image | None = None  # Define screenshot outside try
         try:
             # 1. Capture screenshot
             logger.debug("Taking screenshot...")
@@ -108,9 +106,9 @@ class VisualState:
             else:
                 self.screen_dimensions = None
 
-    def _update_elements_from_parser(self, parser_json: Dict):
+    def _update_elements_from_parser(self, parser_json: dict):
         """Maps the raw JSON output from OmniParser to UIElement objects."""
-        new_elements: List[UIElement] = []
+        new_elements: list[UIElement] = []
         element_id_counter = 0
 
         if not isinstance(parser_json, dict):
@@ -124,7 +122,7 @@ class VisualState:
             self.elements = new_elements
             return
 
-        raw_elements: List[Dict[str, Any]] = parser_json.get("parsed_content_list", [])
+        raw_elements: list[dict[str, Any]] = parser_json.get("parsed_content_list", [])
         if not isinstance(raw_elements, list):
             logger.error(
                 f"Expected 'parsed_content_list' to be a list, got: {type(raw_elements)}"
@@ -142,8 +140,8 @@ class VisualState:
         self.elements = new_elements
 
     def _convert_to_ui_element(
-        self, item: Dict[str, Any], element_id: int
-    ) -> Optional[UIElement]:
+        self, item: dict[str, Any], element_id: int
+    ) -> UIElement | None:
         """Converts a single item from OmniParser result to a UIElement."""
         try:
             if not isinstance(item, dict):
@@ -222,7 +220,7 @@ class VisualState:
             )
             return None
 
-    def find_element(self, description: str) -> Optional[UIElement]:
+    def find_element(self, description: str) -> UIElement | None:
         """Finds the best matching element using basic keyword matching."""
         logger.debug(f"Finding element: '{description}' using basic matching.")
         if not self.elements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,15 +52,31 @@ test = [
     "pytest>=8.0.0",
     "pytest-mock>=3.10.0",
     "pytest-asyncio>=0.23.5",
-    "ruff>=0.11.2",
+    # Bounded on purpose. `ruff>=0.11.2` unpinned is why CI went red without a
+    # code change: ruff 0.16.0 grew its DEFAULT rule set from 59 rules to 413,
+    # and this project selects no rules explicitly, so it silently inherited
+    # 354 new ones. 0.11.2 and 0.14.0 both pass this tree clean (check AND
+    # format); 0.16.0 reports 375. Raise the ceiling deliberately, with the
+    # findings fixed in the same change.
+    "ruff>=0.16,<0.17",
     "mcp[cli]",
 ]
 
-# Add Ruff configuration if you want to manage it here
-# [tool.ruff]
-# line-length = 88
-# select = ["E", "W", "F", "I", "UP", "B", "C4"]
-# ignore = ["E501"] # example
-
-# [tool.ruff.format]
-# quote-style = "double"
+[tool.ruff.lint]
+# BLE001 (blind `except Exception`) is disabled deliberately rather than
+# suppressed at 85 individual sites.
+#
+# OmniMCP is a computer-use agent: essentially every one of those 85 handlers
+# wraps a call into something outside the process -- pynput's platform
+# keyboard/mouse backends, mss screen capture, PIL, the Anthropic API, an
+# OmniParser HTTP server, boto3/EC2, paramiko SSH -- and each one logs the
+# failure and degrades (returns False, falls back to a default, or ends the
+# step) so a single flaky OS or network call cannot kill an agent run. That is
+# the intended design, not laziness.
+#
+# There is also nothing to narrow to. Those libraries share no exception
+# hierarchy, and several raise platform-specific backend errors that are not
+# part of any published API. Enumerating them would silently reintroduce
+# crash-on-first-surprise the next time a dependency added an exception type,
+# which is a behaviour change, not a style change.
+ignore = ["BLE001"]

--- a/run_omnimcp.py
+++ b/run_omnimcp.py
@@ -7,9 +7,9 @@ interfaces for running the MCP server and other utilities.
 """
 
 import asyncio
+
 import fire
 from loguru import logger
-
 from omnimcp.omnimcp import OmniMCP
 
 

--- a/tests/test_agent_executor.py
+++ b/tests/test_agent_executor.py
@@ -1,28 +1,27 @@
 # tests/test_agent_executor.py
 
 import os
-from typing import List, Optional, Tuple
 from unittest.mock import MagicMock
 
 import pytest
 from PIL import Image
 
+from omnimcp import agent_executor
 from omnimcp.agent_executor import (
     AgentExecutor,
-    PerceptionInterface,
     ExecutionInterface,
+    PerceptionInterface,
     PlannerCallable,
 )
-from omnimcp import agent_executor
 from omnimcp.types import LLMActionPlan, UIElement
 
 
 class MockPerception(PerceptionInterface):
     def __init__(
         self,
-        elements: List[UIElement],
-        dims: Optional[Tuple[int, int]],
-        image: Optional[Image.Image],
+        elements: list[UIElement],
+        dims: tuple[int, int] | None,
+        image: Image.Image | None,
     ):
         self.elements = elements
         self.screen_dimensions = dims
@@ -42,23 +41,23 @@ class MockPerception(PerceptionInterface):
 class MockExecution(ExecutionInterface):
     def __init__(self):
         self.calls = []
-        self.fail_on_action: Optional[str] = None  # e.g., "click" to make click fail
+        self.fail_on_action: str | None = None  # e.g., "click" to make click fail
 
     def click(self, x: int, y: int, click_type: str = "single") -> bool:
         self.calls.append(("click", x, y, click_type))
-        return not (self.fail_on_action == "click")
+        return self.fail_on_action != "click"
 
     def type_text(self, text: str) -> bool:
         self.calls.append(("type_text", text))
-        return not (self.fail_on_action == "type")
+        return self.fail_on_action != "type"
 
     def execute_key_string(self, key_info_str: str) -> bool:
         self.calls.append(("execute_key_string", key_info_str))
-        return not (self.fail_on_action == "press_key")
+        return self.fail_on_action != "press_key"
 
     def scroll(self, dx: int, dy: int) -> bool:
         self.calls.append(("scroll", dx, dy))
-        return not (self.fail_on_action == "scroll")
+        return self.fail_on_action != "scroll"
 
 
 # --- Pytest Fixtures ---
@@ -110,8 +109,8 @@ def planner_completes_on_step(n: int) -> PlannerCallable:
     """Factory for a planner that completes on step index `n`."""
 
     def mock_planner(
-        elements: List[UIElement], user_goal: str, action_history: List[str], step: int
-    ) -> Tuple[LLMActionPlan, Optional[UIElement]]:
+        elements: list[UIElement], user_goal: str, action_history: list[str], step: int
+    ) -> tuple[LLMActionPlan, UIElement | None]:
         target_element = elements[0] if elements else None
         is_complete = step == n
         action = "click" if not is_complete else "press_key"  # Vary action
@@ -134,8 +133,8 @@ def planner_never_completes() -> PlannerCallable:
     """Planner that never signals goal completion."""
 
     def mock_planner(
-        elements: List[UIElement], user_goal: str, action_history: List[str], step: int
-    ) -> Tuple[LLMActionPlan, Optional[UIElement]]:
+        elements: list[UIElement], user_goal: str, action_history: list[str], step: int
+    ) -> tuple[LLMActionPlan, UIElement | None]:
         target_element = elements[0] if elements else None
         element_id = target_element.id if target_element else None
         plan = LLMActionPlan(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,8 +2,8 @@
 import pytest
 
 # Assuming imports work based on installation/path
-from omnimcp.core import plan_action_for_ui, LLMActionPlan
-from omnimcp.types import UIElement, Bounds
+from omnimcp.core import LLMActionPlan, plan_action_for_ui
+from omnimcp.types import Bounds, UIElement
 
 # --- Fixture for Sample Elements ---
 
@@ -69,7 +69,7 @@ def test_plan_action_step1_type_user(mocker, sample_elements):
 
     # Assertions
     mock_llm_api.assert_called_once()  # Check API was called
-    call_args, call_kwargs = mock_llm_api.call_args
+    call_args, _call_kwargs = mock_llm_api.call_args
     # Check prompt content (basic check)
     messages = call_args[0]
     assert user_goal in messages[0]["content"]
@@ -119,7 +119,7 @@ def test_plan_action_step3_click_login(mocker, sample_elements):
 
     # Assertions
     mock_llm_api.assert_called_once()
-    call_args, call_kwargs = mock_llm_api.call_args
+    call_args, _call_kwargs = mock_llm_api.call_args
     messages = call_args[0]
     # Check history rendering in prompt
     assert action_history[0] in messages[0]["content"]

--- a/tests/test_deploy_and_parse.py
+++ b/tests/test_deploy_and_parse.py
@@ -5,13 +5,12 @@ A simple script to test OmniParser deployment, screenshotting,
 parsing, and mapping to UIElements using VisualState.
 """
 
-import sys
 import asyncio  # Needed for async VisualState.update()
+import sys
 
-from omnimcp.utils import logger
 from omnimcp.omniparser.client import OmniParserClient
+from omnimcp.utils import logger
 from omnimcp.visual_state import VisualState
-
 
 if __name__ == "__main__":
     logger.info("--- Starting OmniParser Integration Test ---")

--- a/tests/test_omnimcp.py
+++ b/tests/test_omnimcp.py
@@ -2,20 +2,20 @@
 
 """Tests for OmniParser deployment functionality (E2E)."""
 
-import pytest
 import time
-import boto3
-import requests
-from typing import List
 
-from omnimcp.omniparser.server import Deploy
+import boto3
+import pytest
+import requests
+
 from omnimcp.config import config
+from omnimcp.omniparser.server import Deploy
 
 # Import from the new location inside the package
 
 
 # --- Helper Function ---
-def get_running_parser_instances() -> List[dict]:
+def get_running_parser_instances() -> list[dict]:
     """Get any running OmniParser instances."""
     ec2 = boto3.resource("ec2", region_name=config.AWS_REGION)
     instances = list(

--- a/tests/test_omniparser_e2e.py
+++ b/tests/test_omniparser_e2e.py
@@ -3,14 +3,15 @@
 """End-to-end tests for OmniParser deployment and function."""
 
 import time
-import pytest
 from pathlib import Path
-from PIL import Image
 
+import pytest
 from loguru import logger
+from PIL import Image
 
 # Only import OmniParserClient now
 from omnimcp.omniparser.client import OmniParserClient
+
 # Config might still be needed if checking AWS env vars, keep for now
 # from omnimcp.config import config # Removed as test logic doesn't directly use it
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,11 +1,12 @@
 # tests/test_tracking.py
 
+
 import pytest
-from typing import List
+
+from omnimcp.tracking import SimpleElementTracker
 
 # Assuming types and tracker are in these locations
-from omnimcp.types import UIElement, Bounds
-from omnimcp.tracking import SimpleElementTracker
+from omnimcp.types import Bounds, UIElement
 
 # --- Test Helpers ---
 
@@ -108,7 +109,7 @@ def test_update_empty_current_elements(tracker: SimpleElementTracker):
     assert initial_track.latest_element is not None
 
     # Frame 2: Update with empty list
-    frame2_elements: List[UIElement] = []
+    frame2_elements: list[UIElement] = []
     tracked_list = tracker.update(frame2_elements, 2)
 
     assert len(tracked_list) == 1  # Track still exists

--- a/tests/test_visual_state.py
+++ b/tests/test_visual_state.py
@@ -1,15 +1,15 @@
 # tests/test_omnimcp_core.py
 
-import pytest
 from unittest.mock import patch
-from PIL import Image
 
-# Corrected imports based on file moves
-from omnimcp.visual_state import VisualState
+import pytest
+from PIL import Image
 
 # Removed: from omnimcp.mcp_server import OmniMCP (no longer used in this file)
 from omnimcp.synthetic_ui import generate_login_screen
 
+# Corrected imports based on file moves
+from omnimcp.visual_state import VisualState
 
 # --- Fixtures ---
 


### PR DESCRIPTION
CI was red on 375 ruff errors with no code change behind them. `main` has not
been touched since 2025-04-06; the cause is an unpinned linter. Dev deps ask
for `ruff>=0.11.2`, this project selects no rules explicitly (the `[tool.ruff]`
block was entirely commented out), and ruff 0.16.0 grew its DEFAULT rule set
from 59 rules to 413. Verified directly against this tree:

  ruff 0.11.2  check: All checks passed!   format: 29 files already formatted
  ruff 0.14.0  check: All checks passed!   format: 29 files already formatted
  ruff 0.16.0  check: Found 375 errors.    format: 2 files would be reformatted

Fixed in code (285)
-------------------
* UP006/UP045/UP007/UP035 (231) - `List`/`Dict`/`Type` -> builtins,
  `Optional[X]` -> `X | None`. requires-python is >=3.10.
* I001 (28) - import ordering.
* SIM201 (4), SIM102 (2), SIM114 (1), C414 (2), FURB188 (2), UP024 (4),
  RUF010/RUF019/RUF059 - mechanical simplifications.
* `ruff format` (7 files) - 0.16 also formats Python blocks inside Markdown,
  which is why CLAUDE.md and docs/testing_strategy.md move. Whitespace only.

Fixed as real defects (6)
-------------------------
* PIE794 config.py - `OMNIPARSER_DOWNSAMPLE_FACTOR` was declared twice, the
  second time with `Field(ge=0.1, le=1.0)`. The bare `= 1.0` above it was dead
  and silently shadowed. Removed the dead one; the ge/le constraints and the
  1.0 default are confirmed intact on the loaded settings object.
* B006 server.py - `ports: list[int] = [22, config.PORT]` was a shared mutable
  default. Now `None`, resolving to a module-level tuple that is still built at
  import exactly as before, so `config.PORT` is read at the same moment.
* RUF012 input.py - `_special_map_definitions` is only ever read via
  `InputController.`, so it is now a `ClassVar`. 43 entries, unchanged.
* S110 server.py - the SSH readiness probe caught everything and `pass`ed, so a
  wrong key path was indistinguishable from "instance still booting". It now
  logs at debug. Retry behaviour unchanged.
* PLW1510 server.py - `subprocess.run(..., check=False)` states the existing
  behaviour rather than changing it.
* EXE001 - `cli.py` and `run_omnimcp.py` carry shebangs and are entry points
  (`cli.py --help` is the CI smoke test); the executable bit is now set.

DTZ005/DTZ006 (3), fixed without changing behaviour
---------------------------------------------------
* agent_executor run directory name must stay LOCAL wall clock - users
  correlate run folders with their own clock. `now(utc).astimezone()` is the
  same instant with the same rendering; asserted byte-identical.
* server `end_time` is only consumed via `.timestamp()`, where naive-local and
  UTC-aware produce the identical epoch. Pure disambiguation.
* CloudWatch event rendering now says UTC explicitly. This does change the
  printed string, deliberately: it was previously an unlabelled local time
  printed next to AWS's own UTC timestamps.

Disabled deliberately (85)
--------------------------
BLE001 is ignored in `[tool.ruff.lint]`, with the reasoning inline in
pyproject.toml, rather than suppressed at 85 sites with `# noqa`. OmniMCP is a
computer-use agent and essentially every one of those handlers wraps a call
into something outside the process - pynput's platform backends, mss, PIL, the
Anthropic API, an OmniParser HTTP server, boto3/EC2, paramiko - and each logs
and degrades so one flaky OS or network call cannot kill an agent run. Those
libraries share no exception hierarchy and several raise platform-specific
backend errors outside any published API, so enumerating them would silently
reintroduce crash-on-first-surprise. That is a behaviour change, not a style
change.

Also bounded `ruff` to `>=0.16,<0.17` so the next default-rule expansion is an
explicit decision instead of a surprise red CI.

Verified with the exact CI sequence: `ruff check .` clean, `ruff format
--check .` clean, `pytest tests/` 19 passed 1 skipped (identical to the
pre-change baseline), `python cli.py --help` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM